### PR TITLE
Fix invalid filenames

### DIFF
--- a/src/main/java/me/maxih/itunes_backup_explorer/api/BackupFile.java
+++ b/src/main/java/me/maxih/itunes_backup_explorer/api/BackupFile.java
@@ -142,28 +142,21 @@ public class BackupFile {
         try {
             relative = withRelativePath ? Paths.get(this.domain, this.relativePath).toString() : this.getFileName();
         } catch (InvalidPathException e) {
-            e.printStackTrace();
             try {
-                relative = withRelativePath ? Paths.get(this.domain, cleanPath(this.relativePath)).toString() : cleanPath(this.getFileName());
+                relative = withRelativePath
+                        ? Paths.get(this.domain, BackupPathUtils.cleanPath(this.relativePath)).toString()
+                        : BackupPathUtils.cleanPath(this.getFileName());
                 System.out.println("Continuing with invalid characters replaced: " + this.getFileName() + " -> " + relative);
-            } catch (InvalidPathException f) {
-                f.printStackTrace();
-                throw new IOException("Invalid character in filename, failed to replace");
+            } catch (InvalidPathException e1) {
+                throw new IOException("Invalid character in filename, failed to replace", e1);
             }
-
         }
         File destination = new File(destinationFolder.getAbsolutePath(), relative);
         if (destination.exists() && this.fileType != FileType.DIRECTORY)
             throw new FileAlreadyExistsException(destination.getAbsolutePath());
+
         Files.createDirectories(destination.getParentFile().toPath());
         this.extract(destination);
-
-    }
-
-    public String cleanPath(String path)
-    {
-        final String invalid = "[:*?\"<>|]";
-        return path.replaceAll(invalid, "-");
     }
 
     public void replaceWith(File newFile) throws IOException, BackupReadException, UnsupportedCryptoException, NotUnlockedException, DatabaseConnectionException {

--- a/src/main/java/me/maxih/itunes_backup_explorer/util/BackupPathUtils.java
+++ b/src/main/java/me/maxih/itunes_backup_explorer/util/BackupPathUtils.java
@@ -1,8 +1,11 @@
 package me.maxih.itunes_backup_explorer.util;
 
+import java.util.regex.Pattern;
+
 public class BackupPathUtils {
 
     public static final char SEPARATOR = '/';
+    private static final Pattern INVALID_CHARACTERS = Pattern.compile("[:*?\"<>|]");
 
     public static String getParentPath(String path) {
         int lastSep = path.lastIndexOf(SEPARATOR);
@@ -32,6 +35,10 @@ public class BackupPathUtils {
         int lastSep = name.lastIndexOf('.');
         if (lastSep == -1) return "";
         else return name.substring(lastSep + 1);
+    }
+
+    public static String cleanPath(String path) {
+        return INVALID_CHARACTERS.matcher(path).replaceAll("-");
     }
 
     private BackupPathUtils() {


### PR DESCRIPTION
Hey, this looks like it solved the issue on my end. 

- Method cleanPath takes a path string and returns one where invalid characters are replaced with `-`
- Wraps creation of File object referring to destination and the extraction in a try block, catches InvalidPathException.

I only tested that this worked for exporting my SMS attachments from the Files tab, where it worked just fine and exported all 20gbs of them. Did not test exporting by domain or search.