### PR TITLE
Update `org.openjfx` libraries to version 22 + more info on README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+### MacOS
+.DS_Store
+
 ### Maven template
 target/
 pom.xml.tag

--- a/README.md
+++ b/README.md
@@ -26,15 +26,24 @@ Replace `JARFILE.jar` with the name of the file you downloaded.
 
 **macOS**
 - `cd` to the download directory and type in `chmod +x JARFILE.jar`.
-- You may need to enable Full Disk Access in System Preferences ->
-  Security -> Privacy for the [Jar Launcher](https://stackoverflow.com/a/66762230) or Terminal.app / iTerm.app.
 - Now, you should be able to simply double-click the file to start the program.
 - If that does not work, you may need to type `java -jar JARFILE.jar` into the terminal to run it.
+
+**If you have permission issues**
+
+When exporting data from the backup files, you might get `Operation not permitted`
+ errors on your MacBook. To fix this, go to `System Settings > Privacy & Security > Full Disk Access` and add both `java` binary file and the `jar` file you downloaded.
+
+More detailed information can be checked [here](https://stackoverflow.com/questions/65469536/why-does-a-jar-file-have-no-permissions-to-read-from-disk-when-started-via-doubl/66762230#66762230).
 
 **Linux**
 - `cd` to the download directory and type in `chmod +x JARFILE.jar`.
 - Depending on your specific system, you should be able to double-click the file to start the program.
 - If that does not work, use `java -jar JARFILE.jar` to run it.
+
+## How to build
+1. Run `mvn install`
+2. Run `mvn clean compile assembly:single`
 
 ## File Search
 In the "File Search" tab, you can search for files using case-insensitive SQLite LIKE syntax.

--- a/pom.xml
+++ b/pom.xml
@@ -12,12 +12,12 @@
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-controls</artifactId>
-            <version>18</version>
+            <version>22</version>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-fxml</artifactId>
-            <version>18</version>
+            <version>22</version>
         </dependency>
         <dependency>
             <groupId>com.googlecode.plist</groupId>
@@ -37,19 +37,19 @@
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-graphics </artifactId>
-            <version>18</version>
+            <version>22</version>
             <classifier>win</classifier>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-graphics </artifactId>
-            <version>18</version>
+            <version>22</version>
             <classifier>linux</classifier>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-graphics </artifactId>
-            <version>18</version>
+            <version>22</version>
             <classifier>mac</classifier>
         </dependency>
     </dependencies>


### PR DESCRIPTION
At the moment, using `org.openjfx` version `18` on MacOS (tested on `MacOS Sonoma 14.5 (23F79)`) throws a runtime error:

<details>
<summary>Shell output</summary>

```sh
➜  iTunes-Backup-Explorer git:(master) ✗ mvn install
[INFO] Scanning for projects...
[INFO] 
[INFO] ------------------< me.maxih:itunes-backup-explorer >-------------------
[INFO] Building itunes-backup-explorer 1.4-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[WARNING] 6 problems were encountered while building the effective model for org.openjfx:javafx-controls:jar:18
[INFO] 
[INFO] --- resources:3.3.1:resources (default-resources) @ itunes-backup-explorer ---
[INFO] Copying 11 resources from src/main/resources to target/classes
[INFO] 
[INFO] --- compiler:3.10.1:compile (default-compile) @ itunes-backup-explorer ---
[WARNING] *****************************************************************************************************************************************
[WARNING] * Required filename-based automodules detected: [dd-plist-1.23.jar]. Please don't publish this project to a public artifact repository! *
[WARNING] *****************************************************************************************************************************************
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- resources:3.3.1:testResources (default-testResources) @ itunes-backup-explorer ---
[INFO] skip non existing resourceDirectory /Users/brunogeronimo/Documents/dev/others/iTunes-Backup-Explorer/src/test/resources
[INFO] 
[INFO] --- compiler:3.10.1:testCompile (default-testCompile) @ itunes-backup-explorer ---
[INFO] No sources to compile
[INFO] 
[INFO] --- surefire:3.2.5:test (default-test) @ itunes-backup-explorer ---
[INFO] 
[INFO] --- jar:3.4.1:jar (default-jar) @ itunes-backup-explorer ---
[INFO] Building jar: /Users/brunogeronimo/Documents/dev/others/iTunes-Backup-Explorer/target/itunes-backup-explorer-1.4-SNAPSHOT.jar
[INFO] 
[INFO] --- assembly:3.3.0:single (make-assembly) @ itunes-backup-explorer ---
[WARNING] Failed to build parent project for org.openjfx:javafx-controls:jar:18
[WARNING] Failed to build parent project for org.openjfx:javafx-controls:jar:18
[WARNING] Failed to build parent project for org.openjfx:javafx-graphics:jar:18
[WARNING] Failed to build parent project for org.openjfx:javafx-fxml:jar:18
[WARNING] Failed to build parent project for org.openjfx:javafx-fxml:jar:18
[WARNING] Failed to build parent project for org.openjfx:javafx-graphics:jar:18
[WARNING] Failed to build parent project for org.openjfx:javafx-graphics:jar:18
[WARNING] Failed to build parent project for org.openjfx:javafx-base:jar:18
[WARNING] Failed to build parent project for org.openjfx:javafx-base:jar:18
[WARNING] Failed to build parent project for org.openjfx:javafx-graphics:jar:18
[WARNING] Failed to build parent project for org.openjfx:javafx-graphics:jar:18
[INFO] Building jar: /Users/brunogeronimo/Documents/dev/others/iTunes-Backup-Explorer/target/itunes-backup-explorer-1.4-SNAPSHOT-jar-with-dependencies.jar
[INFO] 
[INFO] --- install:3.1.2:install (default-install) @ itunes-backup-explorer ---
[INFO] Installing /Users/brunogeronimo/Documents/dev/others/iTunes-Backup-Explorer/pom.xml to /Users/brunogeronimo/.m2/repository/me/maxih/itunes-backup-explorer/1.4-SNAPSHOT/itunes-backup-explorer-1.4-SNAPSHOT.pom
[INFO] Installing /Users/brunogeronimo/Documents/dev/others/iTunes-Backup-Explorer/target/itunes-backup-explorer-1.4-SNAPSHOT.jar to /Users/brunogeronimo/.m2/repository/me/maxih/itunes-backup-explorer/1.4-SNAPSHOT/itunes-backup-explorer-1.4-SNAPSHOT.jar
[INFO] Installing /Users/brunogeronimo/Documents/dev/others/iTunes-Backup-Explorer/target/itunes-backup-explorer-1.4-SNAPSHOT-jar-with-dependencies.jar to /Users/brunogeronimo/.m2/repository/me/maxih/itunes-backup-explorer/1.4-SNAPSHOT/itunes-backup-explorer-1.4-SNAPSHOT-jar-with-dependencies.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  5.573 s
[INFO] Finished at: 2024-07-27T22:14:15+02:00
[INFO] ------------------------------------------------------------------------
➜  iTunes-Backup-Explorer git:(master) ✗ java -jar target/itunes-backup-explorer-1.4-SNAPSHOT-jar-with-dependencies.jar     
Jul 27, 2024 10:14:22 PM com.sun.javafx.application.PlatformImpl startup
WARNING: Unsupported JavaFX configuration: classes were loaded from 'unnamed module @4464e8f6'
Jul 27, 2024 10:14:27 PM com.sun.glass.ui.mac.MacApplication lambda$waitForReactivation$6
WARNING: Timeout while waiting for app reactivation
2024-07-27 22:14:27.427 java[4476:54781] WARNING: Secure coding is automatically enabled for restorable state! However, not on all supported macOS versions of this application. Opt-in to secure coding explicitly by implementing NSApplicationDelegate.applicationSupportsSecureRestorableState:.
2024-07-27 22:14:28.185 java[4476:54781] *** Assertion failure in -[_NSTrackingAreaAKViewHelper removeTrackingRect:], _NSTrackingAreaAKManager.m:1805
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: '0x0 is an invalid NSTrackingRectTag. Common possible reasons for this are: 1. already removed this trackingRectTag, 2. Truncated the NSTrackingRectTag to 32bit at some point.'
*** First throw call stack:
(
        0   CoreFoundation                      0x000000019aae32ec __exceptionPreprocess + 176
        1   libobjc.A.dylib                     0x000000019a5ca788 objc_exception_throw + 60
        2   Foundation                          0x000000019bc5642c -[NSCalendarDate initWithCoder:] + 0
        3   AppKit                              0x000000019e9c808c -[_NSTrackingAreaAKViewHelper removeTrackingRect:] + 200
        4   libglass.dylib                      0x00000001036b5eb8 Java_com_sun_glass_ui_mac_MacApplication__1getMacKey + 3456
        5   libglass.dylib                      0x00000001036ba578 Java_com_sun_glass_ui_mac_MacApplication__1getMacKey + 21568
        6   AppKit                              0x000000019e30515c -[NSView setFrame:] + 304
        7   libglass.dylib                      0x00000001036ba5d8 Java_com_sun_glass_ui_mac_MacApplication__1getMacKey + 21664
        8   AppKit                              0x000000019e312354 -[NSView resizeWithOldSuperviewSize:] + 488
        9   AppKit                              0x000000019e311d58 -[NSView resizeSubviewsWithOldSize:] + 360
        10  AppKit                              0x000000019e2f70f8 -[NSView setFrameSize:] + 1136
        11  AppKit                              0x000000019e30515c -[NSView setFrame:] + 304
        12  AppKit                              0x000000019e312354 -[NSView resizeWithOldSuperviewSize:] + 488
        13  AppKit                              0x000000019e311d58 -[NSView resizeSubviewsWithOldSize:] + 360
        14  AppKit                              0x000000019e2f70f8 -[NSView setFrameSize:] + 1136
        15  AppKit                              0x000000019e310f3c -[NSThemeFrame setFrameSize:] + 244
        16  AppKit                              0x000000019e3108a0 -[NSWindow _oldPlaceWindow:fromServer:] + 532
        17  AppKit                              0x000000019e30fd5c -[NSWindow _setFrameCommon:display:fromServer:] + 1832
        18  libglass.dylib                      0x00000001036ad738 getImage + 5228
        19  libglass.dylib                      0x00000001036c42ac Java_com_sun_glass_ui_mac_MacWindow__1setBounds2 + 416
        20  ???                                 0x000000011a108d94 0x0 + 4732259732
        21  ???                                 0x000000011a1052d0 0x0 + 4732244688
        22  ???                                 0x000000011a1052d0 0x0 + 4732244688
        23  ???                                 0x000000011a1052d0 0x0 + 4732244688
        24  ???                                 0x000000011a105870 0x0 + 4732246128
        25  ???                                 0x000000011a1052d0 0x0 + 4732244688
        26  ???                                 0x000000011a1052d0 0x0 + 4732244688
        27  ???                                 0x000000011a1052d0 0x0 + 4732244688
        28  ???                                 0x000000011a1052d0 0x0 + 4732244688
        29  ???                                 0x000000011a1052d0 0x0 + 4732244688
        30  ???                                 0x000000011a1052d0 0x0 + 4732244688
        31  ???                                 0x000000011a1052d0 0x0 + 4732244688
        32  ???                                 0x000000011a1052d0 0x0 + 4732244688
        33  ???                                 0x000000011a1052d0 0x0 + 4732244688
        34  ???                                 0x000000011a1052d0 0x0 + 4732244688
        35  ???                                 0x000000011a1052d0 0x0 + 4732244688
        36  ???                                 0x000000011a105870 0x0 + 4732246128
        37  ???                                 0x000000011a1052d0 0x0 + 4732244688
        38  ???                                 0x000000011a105870 0x0 + 4732246128
        39  ???                                 0x000000011a105060 0x0 + 4732244064
        40  ???                                 0x000000011a105600 0x0 + 4732245504
        41  ???                                 0x000000011a105060 0x0 + 4732244064
        42  ???                                 0x000000011a105060 0x0 + 4732244064
        43  ???                                 0x000000011a1052d0 0x0 + 4732244688
        44  ???                                 0x000000011a105870 0x0 + 4732246128
        45  ???                                 0x000000011a100154 0x0 + 4732223828
        46  libjvm.dylib                        0x0000000109b19424 _ZN9JavaCalls11call_helperEP9JavaValueRK12methodHandleP17JavaCallArgumentsP10JavaThread + 604
        47  libjvm.dylib                        0x0000000109b7b3f8 _ZL20jni_invoke_nonstaticP7JNIEnv_P9JavaValueP8_jobject11JNICallTypeP10_jmethodIDP18JNI_ArgumentPusherP10JavaThread + 644
        48  libjvm.dylib                        0x0000000109b7ed0c jni_CallVoidMethod + 212
        49  libglass.dylib                      0x00000001036b1a20 JNI_OnLoad + 204
        50  Foundation                          0x000000019bbbe3f4 __NSThreadPerformPerform + 264
        51  CoreFoundation                      0x000000019aa6e4d8 __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 28
        52  CoreFoundation                      0x000000019aa6e46c __CFRunLoopDoSource0 + 176
        53  CoreFoundation                      0x000000019aa6e1dc __CFRunLoopDoSources0 + 244
        54  CoreFoundation                      0x000000019aa6cdc8 __CFRunLoopRun + 828
        55  CoreFoundation                      0x000000019aa6c434 CFRunLoopRunSpecific + 608
        56  HIToolbox                           0x00000001a521019c RunCurrentEventLoopInMode + 292
        57  HIToolbox                           0x00000001a520ffd8 ReceiveNextEventCommon + 648
        58  HIToolbox                           0x00000001a520fd30 _BlockUntilNextEventMatchingListInModeWithFilter + 76
        59  AppKit                              0x000000019e2cbd68 _DPSNextEvent + 660
        60  AppKit                              0x000000019eac1808 -[NSApplication(NSEventRouting) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 700
        61  AppKit                              0x000000019e2bf09c -[NSApplication run] + 476
        62  libglass.dylib                      0x00000001036b3ba8 JNI_OnLoad + 8788
        63  Foundation                          0x000000019bbbe3f4 __NSThreadPerformPerform + 264
        64  CoreFoundation                      0x000000019aa6e4d8 __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 28
        65  CoreFoundation                      0x000000019aa6e46c __CFRunLoopDoSource0 + 176
        66  CoreFoundation                      0x000000019aa6e1dc __CFRunLoopDoSources0 + 244
        67  CoreFoundation                      0x000000019aa6cdc8 __CFRunLoopRun + 828
        68  CoreFoundation                      0x000000019aa6c434 CFRunLoopRunSpecific + 608
        69  libjli.dylib                        0x0000000102f9f288 CreateExecutionEnvironment + 400
        70  libjli.dylib                        0x0000000102f9b43c JLI_Launch + 1128
        71  java                                0x0000000102b13bac main + 392
        72  dyld                                0x000000019a6060e0 start + 2360
)
libc++abi: terminating due to uncaught exception of type NSException
[1]    4476 abort      java -jar target/itunes-backup-explorer-1.4-SNAPSHOT-jar-with-dependencies.jar
```
</details>

To fix this issue, according to [this answer](https://stackoverflow.com/questions/78274903/secure-coding-is-not-enabled-for-restorable-state-enable-secure-coding-by-imple) on Stack Overflow, all we need to do is to update the package to version 21 or newer. I upgraded it to version 22.

Also, I added a bit more details on how to run/build the app.