### PR TITLE
Use NIO for file decryption

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,12 @@
             <version>22</version>
             <classifier>mac</classifier>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.11.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/me/maxih/itunes_backup_explorer/api/KeyBag.java
+++ b/src/main/java/me/maxih/itunes_backup_explorer/api/KeyBag.java
@@ -179,7 +179,7 @@ public class KeyBag {
 
     public void decryptFile(byte[] protectionClass, byte[] persistentKey, File source, File destination, long size) throws IOException, BackupReadException, UnsupportedCryptoException, NotUnlockedException, InvalidKeyException {
         try {
-            var cipher = Cipher.getInstance("AES/CBC/NoPadding");
+            var cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
             cipher.init(
                     Cipher.DECRYPT_MODE,
                     new SecretKeySpec(this.unwrapKeyForClass(protectionClass, persistentKey), "AES"),
@@ -231,7 +231,7 @@ public class KeyBag {
         byte[] key = this.unwrapKeyForClass(protectionClass, persistentKey);
 
         try {
-            Cipher c = Cipher.getInstance("AES/CBC/NoPadding");
+            Cipher c = Cipher.getInstance("AES/CBC/PKCS5Padding");
             c.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(key, "AES"), new IvParameterSpec(new byte[16]));
             return new CipherOutputStream(destination, c);
         } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidAlgorithmParameterException e) {
@@ -247,10 +247,6 @@ public class KeyBag {
                 OutputStream encryptStream = encryptStream(protectionClass, persistentKey, outputStream)
         ) {
             inputStream.transferTo(encryptStream);
-            long mod = source.length() % 16;
-            if (mod != 0) {
-                encryptStream.write(new byte[16 - (int) mod]);
-            }
         }
     }
 

--- a/src/test/java/me/maxih/itunes_backup_explorer/api/KeyBagTest.java
+++ b/src/test/java/me/maxih/itunes_backup_explorer/api/KeyBagTest.java
@@ -1,0 +1,134 @@
+package me.maxih.itunes_backup_explorer.api;
+
+import com.dd.plist.NSData;
+import org.bouncycastle.crypto.digests.SHA1Digest;
+import org.bouncycastle.crypto.generators.PKCS5S2ParametersGenerator;
+import org.bouncycastle.crypto.params.KeyParameter;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.security.spec.KeySpec;
+import java.util.Arrays;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class KeyBagTest {
+
+    private static byte[] protectionClass;
+    private static byte[] persistentKey;
+    private static KeyBag keyBag;
+
+    @BeforeAll
+    static void create() throws Exception {
+        var data = ByteBuffer.allocate(1024);
+
+        var uuid = UUID.randomUUID();
+        data.put("UUID".getBytes(StandardCharsets.US_ASCII));
+        data.putInt(16);
+        data.putLong(uuid.getMostSignificantBits());
+        data.putLong(uuid.getLeastSignificantBits());
+
+        data.put("WRAP".getBytes(StandardCharsets.US_ASCII));
+        data.putInt(4);
+        data.putInt(2);
+
+        // Salt 1
+        var salt1 = new byte[32];
+        ThreadLocalRandom.current().nextBytes(salt1);
+        data.put("DPSL".getBytes(StandardCharsets.US_ASCII));
+        data.putInt(salt1.length);
+        data.put(salt1);
+
+        // Iterations 1
+        data.put("DPIC".getBytes(StandardCharsets.US_ASCII));
+        data.putInt(4);
+        data.putInt(1);
+
+        // Salt 2
+        var salt2 = new byte[32];
+        ThreadLocalRandom.current().nextBytes(salt2);
+        data.put("SALT".getBytes(StandardCharsets.US_ASCII));
+        data.putInt(salt2.length);
+        data.put(salt2);
+
+        // Iterations 2
+        data.put("ITER".getBytes(StandardCharsets.US_ASCII));
+        data.putInt(4);
+        data.putInt(1);
+
+        var uuid2 = UUID.randomUUID();
+        protectionClass = new byte[16];
+        ByteBuffer.wrap(protectionClass)
+                .putLong(uuid2.getMostSignificantBits())
+                .putLong(uuid2.getLeastSignificantBits());
+
+        data.put("UUID".getBytes(StandardCharsets.US_ASCII));
+        data.putInt(protectionClass.length);
+        data.put(protectionClass);
+
+        KeySpec spec1 = new PBEKeySpec("password".toCharArray(), salt1, 1, 32 * 8);
+        SecretKeyFactory f1 = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
+        SecretKey key1 = f1.generateSecret(spec1);
+        PKCS5S2ParametersGenerator gen = new PKCS5S2ParametersGenerator(new SHA1Digest());
+        gen.init(key1.getEncoded(), salt2, 1);
+        byte[] keyEncryptionKey = ((KeyParameter) gen.generateDerivedParameters(32 * 8)).getKey();
+
+        Cipher c = Cipher.getInstance("AESWrap");
+        c.init(Cipher.WRAP_MODE, new SecretKeySpec(keyEncryptionKey, "AES"));
+        persistentKey = c.wrap(key1);
+
+        // Why is keyEncryptionKey getting encrypted with keyEncryptionKey?
+        c.init(Cipher.WRAP_MODE, new SecretKeySpec(keyEncryptionKey, "AES"));
+        var wrappedKey = c.wrap(new SecretKeySpec(keyEncryptionKey, "AES"));
+        data.put("WPKY".getBytes(StandardCharsets.US_ASCII));
+        data.putInt(wrappedKey.length);
+        data.put(wrappedKey);
+
+        data.put("WRAP".getBytes(StandardCharsets.US_ASCII));
+        data.putInt(4);
+        data.putInt(2);
+
+        data.flip();
+        var d2 = new byte[data.remaining()];
+        data.get(d2);
+
+        keyBag = new KeyBag(new NSData(d2));
+        keyBag.unlock("password");
+    }
+
+    @Test
+    void decryptFile() throws Exception {
+        for (int size = 0; size < 128; ++size) {
+            var plain = Files.createTempFile("plain-" + size, "-");
+            plain.toFile().deleteOnExit();
+            var cipher = Files.createTempFile("cipher-" + size, "-");
+            cipher.toFile().deleteOnExit();
+            var verify = Files.createTempFile("verify-" + size, "-");
+            verify.toFile().deleteOnExit();
+
+            var data = new byte[size];
+            ThreadLocalRandom.current().nextBytes(data);
+            Files.write(plain, data);
+
+            keyBag.encryptFile(protectionClass, persistentKey, plain.toFile(), cipher.toFile());
+            if (size > 0) {
+                assertFalse(Arrays.equals(Files.readAllBytes(plain), Files.readAllBytes(cipher)));
+            }
+
+            keyBag.decryptFile(protectionClass, persistentKey, cipher.toFile(), verify.toFile(), size);
+            assertArrayEquals(Files.readAllBytes(plain), Files.readAllBytes(verify));
+        }
+    }
+}
+


### PR DESCRIPTION
Refactor the decryption code to use NIO classes. There's a pretty good performance win, and I think it's due to a combination of larger buffers and fewer intermediate buffers.

I tested it by extracting with the modified code and comparing the restored files.

To get an estimate of the performance win, I wrote quick test script that uses similar decrypt implementations over different file sizes:

https://gist.github.com/ehrmann/e80e4eda48b839d41d9cd52d0ba551ee

Windows:
```
 size,       old,       new
   1K,      1969,      1399
   2K,      2066,      1339
   4K,      1893,      1357
   8K,      1921,      1355
  16K,      2172,      1390
  32K,      2270,      1484
  64K,      2632,      1518
 128K,      2767,      1684
 256K,      3469,      1962
 512K,      5074,      2643
1024K,      7862,      3724
2048K,     13456,      6070
4096K,     26723,     12902
```

FreeBSD
```
 size,       old,       new
   1K,        60,        42
   2K,        96,        21
   4K,        17,        42
   8K,        34,        28
  16K,        44,        37
  32K,        83,        55
  64K,       120,        78
 128K,       189,       135
 256K,       397,       144
 512K,       306,       376
1024K,      1136,       591
2048K,      1444,       640
4096K,      3563,      2326
```

Linux
```
 size,       old,       new
   1K,       105,        35
   2K,       107,        34
   4K,       107,        32
   8K,       120,        42
  16K,       127,        40
  32K,       165,        47
  64K,       192,        64
 128K,       278,        98
 256K,       438,       160
 512K,       773,       292
1024K,      1422,       525
2048K,      2680,      1047
4096K,      5207,      2020
```